### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Claude MCP server for exploring and managing your Keboola Connection project. This server provides tools and resources to interact with Keboola's Storage API, allowing you to browse buckets, tables, and components.
 
+<a href="https://glama.ai/mcp/servers/72mwt1x862"><img width="380" height="200" src="https://glama.ai/mcp/servers/72mwt1x862/badge" alt="Keboola Explorer Server MCP server" /></a>
+
 ## Prerequisites
 
 - [Claude Desktop](https://claude.ai/download) installed and updated to the latest version


### PR DESCRIPTION
This PR adds a badge for the [Keboola Explorer MCP Server](https://glama.ai/mcp/servers/72mwt1x862) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/72mwt1x862"><img width="380" height="200" src="https://glama.ai/mcp/servers/72mwt1x862/badge" alt="Keboola Explorer Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.