### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use a Python image with uv pre-installed
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS uv
+
+# Install the project into /app
+WORKDIR /app
+
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Install the project's dependencies using the lockfile and settings
+COPY uv.lock pyproject.toml /app/
+RUN --mount=type=cache,target=/root/.cache/uv     uv sync --frozen --no-install-project --no-dev --no-editable
+
+# Then, add the rest of the project source code and install it
+# Installing separately from its dependencies allows optimal layer caching
+ADD src /app/src
+RUN --mount=type=cache,target=/root/.cache/uv     uv sync --frozen --no-dev --no-editable
+
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app
+ 
+COPY --from=uv /root/.local /root/.local
+COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+# when running the container, add --api-url and a bind mount to the host's db file
+ENTRYPOINT ["python", "-m", "keboola_mcp_server.cli", "--api-url", "https://connection.YOUR_REGION.keboola.com", "--log-level", "DEBUG"]

--- a/README.md
+++ b/README.md
@@ -3,11 +3,21 @@
 [![CI](https://github.com/jordanburger/keboola-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/jordanburger/keboola-mcp-server/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/jordanburger/keboola-mcp-server/branch/main/graph/badge.svg)](https://codecov.io/gh/jordanburger/keboola-mcp-server)
 <a href="https://glama.ai/mcp/servers/72mwt1x862"><img width="380" height="200" src="https://glama.ai/mcp/servers/72mwt1x862/badge" alt="Keboola Explorer Server MCP server" /></a>
+[![smithery badge](https://smithery.ai/badge/keboola-mcp-server)](https://smithery.ai/server/keboola-mcp-server)
 
 A Model Context Protocol (MCP) server for interacting with Keboola Connection. This server provides tools for listing and accessing data from Keboola Storage API.
 
 ## Installation
 
+### Installing via Smithery
+
+To install Keboola Explorer for Claude Desktop automatically via [Smithery](https://smithery.ai/server/keboola-mcp-server):
+
+```bash
+npx -y @smithery/cli install keboola-mcp-server --client claude
+```
+
+### Manual Installation
 First, clone the repository and create a virtual environment:
 
 ```bash

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,22 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - kbcStorageToken
+      - apiUrl
+    properties:
+      kbcStorageToken:
+        type: string
+        description: The Keboola Storage API token.
+      apiUrl:
+        type: string
+        description: The API URL for the Keboola region (e.g.,
+          https://connection.YOUR_REGION.keboola.com).
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'python', args: ['-m', 'keboola_mcp_server.cli', '--api-url', config.apiUrl, '--log-level', 'DEBUG'], env: { KBC_STORAGE_TOKEN: config.kbcStorageToken }})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and the configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/keboola-mcp-server) and claiming it.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂